### PR TITLE
Hot redeploy on windows 9.4.11.v20180605

### DIFF
--- a/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebInfConfiguration.java
+++ b/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebInfConfiguration.java
@@ -642,8 +642,14 @@ public class WebInfConfiguration extends AbstractConfiguration
                     }
                     else
                     {
+                        long lastModified;
+                        // read last modified without caching a war file
+                        // so that webapp can be redeployed on Windows
+                        try (Resource r = Resource.newResource("jar:" + web_app + "!/", false)) {
+                            lastModified = r.lastModified();
+                        }
                         //only extract if the war file is newer, or a .extract_lock file is left behind meaning a possible partial extraction
-                        if (web_app.lastModified() > extractedWebAppDir.lastModified() || extractionLock.exists())
+                        if (lastModified > extractedWebAppDir.lastModified() || extractionLock.exists())
                         {
                             extractionLock.createNewFile();
                             IO.delete(extractedWebAppDir);

--- a/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebInfConfiguration.java
+++ b/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebInfConfiguration.java
@@ -645,7 +645,7 @@ public class WebInfConfiguration extends AbstractConfiguration
                         long lastModified;
                         // read last modified without caching a war file
                         // so that webapp can be redeployed on Windows
-                        try (Resource r = Resource.newResource("jar:" + web_app + "!/", false)) {
+                        try (Resource r = Resource.newResource(web_app.getURL().toExternalForm(), false)) {
                             lastModified = r.lastModified();
                         }
                         //only extract if the war file is newer, or a .extract_lock file is left behind meaning a possible partial extraction

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <alpn.api.version>1.1.3.v20160715</alpn.api.version>
     <jsp.version>8.5.24.2</jsp.version>
     <!-- default values are unsupported, but required to be defined for reactor sanity reasons -->
-    <alpn.version>undefined</alpn.version>
+    <alpn.version>8.1.0.v20141016</alpn.version>
     <conscrypt.version>1.0.0.RC11</conscrypt.version>
     <asm.version>6.2</asm.version>
     <jmh.version>1.20</jmh.version>


### PR DESCRIPTION
@serba - applied your patches to a new branch from the `9.4.11.v20180605` tag. Looks like we'll need to create a new branch, based on `9.4.11.v20180605`, on your repo before this PR can be meregable.

Also, there was a recent comment on your issue: https://github.com/eclipse/jetty.project/issues/2835

- note: I'm just messin' around w/getting dependencies updated, which ended up requiring a Jetty update - so if you had plans to deal with this differently, no worries.